### PR TITLE
make sure all C-imported enums are cint sized

### DIFF
--- a/src/hlibgit2/apply.nim
+++ b/src/hlibgit2/apply.nim
@@ -6,10 +6,10 @@ import
   ./types
 
 type
-  c_git_apply_flags_t* = enum
+  c_git_apply_flags_t* {.size: sizeof(cint).} = enum
     c_GIT_APPLY_CHECK = 1 shl 0
 
-  c_git_apply_location_t* = enum
+  c_git_apply_location_t* {.size: sizeof(cint).} = enum
     c_GIT_APPLY_LOCATION_WORKDIR = 0 shl 0
     c_GIT_APPLY_LOCATION_INDEX   = 1 shl 0
     c_GIT_APPLY_LOCATION_BOTH    = 1 shl 1

--- a/src/hlibgit2/attr.nim
+++ b/src/hlibgit2/attr.nim
@@ -6,7 +6,7 @@ import
   ./types
 
 type
-  c_git_attr_value_t* = enum
+  c_git_attr_value_t* {.size: sizeof(cint).} = enum
     c_GIT_ATTR_VALUE_UNSPECIFIED = 0
     c_GIT_ATTR_VALUE_TRUE        = 1 ## The attribute has been left unspecified
     c_GIT_ATTR_VALUE_FALSE       = 2 ## The attribute has been set

--- a/src/hlibgit2/blame.nim
+++ b/src/hlibgit2/blame.nim
@@ -6,7 +6,7 @@ import
   ./types
 
 type
-  c_git_blame_flag_t* = enum
+  c_git_blame_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_BLAME_NORMAL                          = 0 shl 0 ## Normal blame, the default
     c_GIT_BLAME_TRACK_COPIES_SAME_FILE          = 1 shl 0
     c_GIT_BLAME_TRACK_COPIES_SAME_COMMIT_MOVES  = 1 shl 1

--- a/src/hlibgit2/blob.nim
+++ b/src/hlibgit2/blob.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_blob_filter_flag_t* = enum
+  c_git_blob_filter_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_BLOB_FILTER_CHECK_FOR_BINARY       = 1 shl 0 ## When set, filters will not be applied to binary files.
     c_GIT_BLOB_FILTER_NO_SYSTEM_ATTRIBUTES   = 1 shl 1
     c_GIT_BLOB_FILTER_ATTRIBUTES_FROM_HEAD   = 1 shl 2

--- a/src/hlibgit2/cert.nim
+++ b/src/hlibgit2/cert.nim
@@ -4,7 +4,7 @@ import
   ./libgit2_config
 
 type
-  c_git_cert_ssh_raw_type_t* = enum
+  c_git_cert_ssh_raw_type_t* {.size: sizeof(cint).} = enum
     c_GIT_CERT_SSH_RAW_TYPE_UNKNOWN       = 0 ## The raw key is of an unknown type.
     c_GIT_CERT_SSH_RAW_TYPE_RSA           = 1 ## The raw key is an RSA key.
     c_GIT_CERT_SSH_RAW_TYPE_DSS           = 2 ## The raw key is a DSS key.
@@ -13,13 +13,13 @@ type
     c_GIT_CERT_SSH_RAW_TYPE_KEY_ECDSA_521 = 5 ## The raw key is a ECDSA 521 key.
     c_GIT_CERT_SSH_RAW_TYPE_KEY_ED25519   = 6 ## The raw key is a ED25519 key.
 
-  c_git_cert_ssh_t* = enum
+  c_git_cert_ssh_t* {.size: sizeof(cint).} = enum
     c_GIT_CERT_SSH_MD5    = 1 shl 0 ## MD5 is available
     c_GIT_CERT_SSH_SHA1   = 1 shl 1 ## SHA-1 is available
     c_GIT_CERT_SSH_SHA256 = 1 shl 2 ## SHA-256 is available
     c_GIT_CERT_SSH_RAW    = 1 shl 3 ## Raw hostkey is available
 
-  c_git_cert_t* = enum
+  c_git_cert_t* {.size: sizeof(cint).} = enum
     c_GIT_CERT_NONE            = 0
     c_GIT_CERT_X509            = 1
     c_GIT_CERT_HOSTKEY_LIBSSH2 = 2

--- a/src/hlibgit2/checkout.nim
+++ b/src/hlibgit2/checkout.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_checkout_notify_t* = enum
+  c_git_checkout_notify_t* {.size: sizeof(cint).} = enum
     c_GIT_CHECKOUT_NOTIFY_NONE      = 0 shl 0
     c_GIT_CHECKOUT_NOTIFY_CONFLICT  = 1 shl 0
     c_GIT_CHECKOUT_NOTIFY_DIRTY     = 1 shl 1
@@ -15,7 +15,7 @@ type
     c_GIT_CHECKOUT_NOTIFY_UNTRACKED = 1 shl 3
     c_GIT_CHECKOUT_NOTIFY_IGNORED   = 1 shl 4
 
-  c_git_checkout_strategy_t* = enum
+  c_git_checkout_strategy_t* {.size: sizeof(cint).} = enum
     c_GIT_CHECKOUT_NONE                         = 0 shl 0
     c_GIT_CHECKOUT_SAFE                         = 1 shl 0  ## default is a dry run, no actual updates
     c_GIT_CHECKOUT_FORCE                        = 1 shl 1

--- a/src/hlibgit2/clone.nim
+++ b/src/hlibgit2/clone.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_clone_local_t* = enum
+  c_git_clone_local_t* {.size: sizeof(cint).} = enum
     c_GIT_CLONE_LOCAL_AUTO     = 0
     c_GIT_CLONE_LOCAL          = 1
     c_GIT_CLONE_NO_LOCAL       = 2

--- a/src/hlibgit2/common.nim
+++ b/src/hlibgit2/common.nim
@@ -4,13 +4,13 @@ import
   ./libgit2_config
 
 type
-  c_git_feature_t* = enum
+  c_git_feature_t* {.size: sizeof(cint).} = enum
     c_GIT_FEATURE_THREADS = 1 shl 0
     c_GIT_FEATURE_HTTPS   = 1 shl 1
     c_GIT_FEATURE_SSH     = 1 shl 2
     c_GIT_FEATURE_NSEC    = 1 shl 3
 
-  c_git_libgit2_opt_t* = enum
+  c_git_libgit2_opt_t* {.size: sizeof(cint).} = enum
     c_GIT_OPT_GET_MWINDOW_SIZE                    = 0
     c_GIT_OPT_SET_MWINDOW_SIZE                    = 1
     c_GIT_OPT_GET_MWINDOW_MAPPED_LIMIT            = 2

--- a/src/hlibgit2/config.nim
+++ b/src/hlibgit2/config.nim
@@ -6,7 +6,7 @@ import
   ./types
 
 type
-  c_git_config_level_t* = enum
+  c_git_config_level_t* {.size: sizeof(cint).} = enum
     c_GIT_CONFIG_HIGHEST_LEVEL     = -1
     c_GIT_CONFIG_LEVEL_PROGRAMDATA = 1  ## System-wide on Windows, for compatibility with portable git
     c_GIT_CONFIG_LEVEL_SYSTEM      = 2  ## System-wide configuration file; /etc/gitconfig on Linux systems
@@ -15,7 +15,7 @@ type
     c_GIT_CONFIG_LEVEL_LOCAL       = 5
     c_GIT_CONFIG_LEVEL_APP         = 6
 
-  c_git_configmap_t* = enum
+  c_git_configmap_t* {.size: sizeof(cint).} = enum
     c_GIT_CONFIGMAP_FALSE  = 0
     c_GIT_CONFIGMAP_TRUE   = 1
     c_GIT_CONFIGMAP_INT32  = 2

--- a/src/hlibgit2/credential.nim
+++ b/src/hlibgit2/credential.nim
@@ -12,7 +12,7 @@ type
 
   LIBSSH2_USERAUTH_KBDINT_RESPONSE1* = LIBSSH2_USERAUTH_KBDINT_RESPONSE
 
-  c_git_credential_t* = enum
+  c_git_credential_t* {.size: sizeof(cint).} = enum
     c_GIT_CREDENTIAL_USERPASS_PLAINTEXT = 1 shl 0
     c_GIT_CREDENTIAL_SSH_KEY            = 1 shl 1
     c_GIT_CREDENTIAL_SSH_CUSTOM         = 1 shl 2

--- a/src/hlibgit2/describe.nim
+++ b/src/hlibgit2/describe.nim
@@ -6,7 +6,7 @@ import
   ./types
 
 type
-  c_git_describe_strategy_t* = enum
+  c_git_describe_strategy_t* {.size: sizeof(cint).} = enum
     c_GIT_DESCRIBE_DEFAULT = 0 shl 0
     c_GIT_DESCRIBE_TAGS    = 1 shl 0
     c_GIT_DESCRIBE_ALL     = 1 shl 1

--- a/src/hlibgit2/diff.nim
+++ b/src/hlibgit2/diff.nim
@@ -8,7 +8,7 @@ import
   ./types
 
 type
-  c_git_delta_t* = enum
+  c_git_delta_t* {.size: sizeof(cint).} = enum
     c_GIT_DELTA_UNMODIFIED = 0
     c_GIT_DELTA_ADDED      = 1  ## no changes
     c_GIT_DELTA_DELETED    = 2  ## entry does not exist in old version
@@ -21,12 +21,12 @@ type
     c_GIT_DELTA_UNREADABLE = 9  ## type of entry changed between old and new
     c_GIT_DELTA_CONFLICTED = 10 ## entry is unreadable
 
-  c_git_diff_binary_t* = enum
+  c_git_diff_binary_t* {.size: sizeof(cint).} = enum
     c_GIT_DIFF_BINARY_NONE    = 0 shl 0 ## There is no binary delta.
     c_GIT_DIFF_BINARY_LITERAL = 1 shl 0 ## The binary data is the literal contents of the file.
     c_GIT_DIFF_BINARY_DELTA   = 1 shl 1 ## The binary data is the delta from one side to the other.
 
-  c_git_diff_find_t* = enum
+  c_git_diff_find_t* {.size: sizeof(cint).} = enum
     c_GIT_DIFF_FIND_BY_CONFIG                  = 0     ## Obey `diff.renames`. Overridden by any other GIT_DIFF_FIND_... flag.
     c_GIT_DIFF_FIND_RENAMES                    = 1     ## Look for renames? (`--find-renames`)
     c_GIT_DIFF_FIND_RENAMES_FROM_REWRITES      = 2     ## Consider old side of MODIFIED for renames? (`--break-rewrites=N`)
@@ -42,17 +42,17 @@ type
     c_GIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY = 32768
     c_GIT_DIFF_FIND_REMOVE_UNMODIFIED          = 65536
 
-  c_git_diff_flag_t* = enum
+  c_git_diff_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_DIFF_FLAG_BINARY     = 1 shl 0
     c_GIT_DIFF_FLAG_NOT_BINARY = 1 shl 1 ## file(s) treated as binary data
     c_GIT_DIFF_FLAG_VALID_ID   = 1 shl 2 ## file(s) treated as text data
     c_GIT_DIFF_FLAG_EXISTS     = 1 shl 3 ## `id` value is known correct
 
-  c_git_diff_format_email_flags_t* = enum
+  c_git_diff_format_email_flags_t* {.size: sizeof(cint).} = enum
     c_GIT_DIFF_FORMAT_EMAIL_NONE                         = 0 shl 0 ## Normal patch, the default
     c_GIT_DIFF_FORMAT_EMAIL_EXCLUDE_SUBJECT_PATCH_MARKER = 1 shl 0 ## Don't insert "[PATCH]" in the subject header
 
-  c_git_diff_format_t* = enum
+  c_git_diff_format_t* {.size: sizeof(cint).} = enum
     c_GIT_DIFF_FORMAT_PATCH        = 1
     c_GIT_DIFF_FORMAT_PATCH_HEADER = 2 ## full git diff
     c_GIT_DIFF_FORMAT_RAW          = 3 ## just the file headers of patch
@@ -60,10 +60,10 @@ type
     c_GIT_DIFF_FORMAT_NAME_STATUS  = 5 ## like git diff --name-only
     c_GIT_DIFF_FORMAT_PATCH_ID     = 6 ## like git diff --name-status
 
-  c_git_diff_line_t* = enum
+  c_git_diff_line_t* {.size: sizeof(cint).} = enum
     c_GIT_DIFF_LINE_CONTEXT = 39 ## These values will be sent to `git_diff_line_cb` along with the line
 
-  c_git_diff_option_t* = enum
+  c_git_diff_option_t* {.size: sizeof(cint).} = enum
     c_GIT_DIFF_NORMAL                          = 0 shl 0  ## Normal diff, the default
     c_GIT_DIFF_REVERSE                         = 1 shl 0  ## Reverse the sides of the diff
     c_GIT_DIFF_INCLUDE_IGNORED                 = 1 shl 1  ## Include ignored files in the diff
@@ -96,7 +96,7 @@ type
     c_GIT_DIFF_SHOW_BINARY                     = 1 shl 30
     c_GIT_DIFF_IGNORE_BLANK_LINES              = 1 shl 31 ## Ignore blank lines
 
-  c_git_diff_stats_format_t* = enum
+  c_git_diff_stats_format_t* {.size: sizeof(cint).} = enum
     c_GIT_DIFF_STATS_NONE            = 0 shl 0 ## No stats
     c_GIT_DIFF_STATS_FULL            = 1 shl 0 ## Full statistics, equivalent of `--stat`
     c_GIT_DIFF_STATS_SHORT           = 1 shl 1 ## Short statistics, equivalent of `--shortstat`

--- a/src/hlibgit2/errors.nim
+++ b/src/hlibgit2/errors.nim
@@ -4,7 +4,7 @@ import
   ./libgit2_config
 
 type
-  c_git_error_code* = enum
+  c_git_error_code* {.size: sizeof(cint).} = enum
     c_GIT_EAPPLYFAIL      = -35 ## Unsaved changes in the index would be overwritten
     c_GIT_EINDEXDIRTY     = -34 ## Hashsum mismatch in object
     c_GIT_EMISMATCH       = -33 ## Internal only
@@ -36,7 +36,7 @@ type
     c_GIT_ERROR           = -1  ## No error
     c_GIT_OK              = 0
 
-  c_git_error_t* = enum
+  c_git_error_t* {.size: sizeof(cint).} = enum
     c_GIT_ERROR_NONE       = 0
     c_GIT_ERROR_NOMEMORY   = 1
     c_GIT_ERROR_OS         = 2

--- a/src/hlibgit2/filter.nim
+++ b/src/hlibgit2/filter.nim
@@ -7,14 +7,14 @@ import
   ./types
 
 type
-  c_git_filter_flag_t* = enum
+  c_git_filter_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_FILTER_DEFAULT                = 0 shl 0
     c_GIT_FILTER_ALLOW_UNSAFE           = 1 shl 0 ## Don't error for `safecrlf` violations, allow them to continue.
     c_GIT_FILTER_NO_SYSTEM_ATTRIBUTES   = 1 shl 1 ## Don't load `/etc/gitattributes` (or the system equivalent)
     c_GIT_FILTER_ATTRIBUTES_FROM_HEAD   = 1 shl 2 ## Load attributes from `.gitattributes` in the root of HEAD
     c_GIT_FILTER_ATTRIBUTES_FROM_COMMIT = 1 shl 3
 
-  c_git_filter_mode_t* = enum
+  c_git_filter_mode_t* {.size: sizeof(cint).} = enum
     c_GIT_FILTER_TO_WORKTREE = 0 shl 0
     c_GIT_FILTER_TO_ODB      = 1 shl 0
 

--- a/src/hlibgit2/index.nim
+++ b/src/hlibgit2/index.nim
@@ -7,28 +7,28 @@ import
   ./types
 
 type
-  c_git_index_add_option_t* = enum
+  c_git_index_add_option_t* {.size: sizeof(cint).} = enum
     c_GIT_INDEX_ADD_DEFAULT                = 0 shl 0
     c_GIT_INDEX_ADD_FORCE                  = 1 shl 0
     c_GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH = 1 shl 1
     c_GIT_INDEX_ADD_CHECK_PATHSPEC         = 1 shl 2
 
-  c_git_index_capability_t* = enum
+  c_git_index_capability_t* {.size: sizeof(cint).} = enum
     c_GIT_INDEX_CAPABILITY_FROM_OWNER  = -1
     c_GIT_INDEX_CAPABILITY_IGNORE_CASE = 1
     c_GIT_INDEX_CAPABILITY_NO_FILEMODE = 2
     c_GIT_INDEX_CAPABILITY_NO_SYMLINKS = 4
 
-  c_git_index_entry_extended_flag_t* = enum
+  c_git_index_entry_extended_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_INDEX_ENTRY_UPTODATE       = 4
     c_GIT_INDEX_ENTRY_INTENT_TO_ADD  = 8192
     c_GIT_INDEX_ENTRY_SKIP_WORKTREE  = 16384
     c_GIT_INDEX_ENTRY_EXTENDED_FLAGS = 24576
 
-  c_git_index_entry_flag_t* = enum
+  c_git_index_entry_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_INDEX_ENTRY_EXTENDED = 0 shl 0
 
-  c_git_index_stage_t* = enum
+  c_git_index_stage_t* {.size: sizeof(cint).} = enum
     c_GIT_INDEX_STAGE_ANY      = -1
     c_GIT_INDEX_STAGE_NORMAL   = 0  ## A normal staged file in the index.
     c_GIT_INDEX_STAGE_ANCESTOR = 1  ## The ancestor side of a conflict.

--- a/src/hlibgit2/merge.nim
+++ b/src/hlibgit2/merge.nim
@@ -10,20 +10,20 @@ import
   ./types
 
 type
-  c_git_merge_analysis_t* = enum
+  c_git_merge_analysis_t* {.size: sizeof(cint).} = enum
     c_GIT_MERGE_ANALYSIS_NONE        = 0 shl 0 ## No merge is possible.  (Unused.)
     c_GIT_MERGE_ANALYSIS_NORMAL      = 1 shl 0
     c_GIT_MERGE_ANALYSIS_UP_TO_DATE  = 1 shl 1
     c_GIT_MERGE_ANALYSIS_FASTFORWARD = 1 shl 2
     c_GIT_MERGE_ANALYSIS_UNBORN      = 1 shl 3
 
-  c_git_merge_file_favor_t* = enum
+  c_git_merge_file_favor_t* {.size: sizeof(cint).} = enum
     c_GIT_MERGE_FILE_FAVOR_NORMAL = 0
     c_GIT_MERGE_FILE_FAVOR_OURS   = 1
     c_GIT_MERGE_FILE_FAVOR_THEIRS = 2
     c_GIT_MERGE_FILE_FAVOR_UNION  = 3
 
-  c_git_merge_file_flag_t* = enum
+  c_git_merge_file_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_MERGE_FILE_DEFAULT                  = 0 shl 0 ## Defaults
     c_GIT_MERGE_FILE_STYLE_MERGE              = 1 shl 0 ## Create standard conflicted merge files
     c_GIT_MERGE_FILE_STYLE_DIFF3              = 1 shl 1 ## Create diff3-style files
@@ -34,13 +34,13 @@ type
     c_GIT_MERGE_FILE_DIFF_PATIENCE            = 1 shl 6 ## Use the "patience diff" algorithm
     c_GIT_MERGE_FILE_DIFF_MINIMAL             = 1 shl 7 ## Take extra time to find minimal diff
 
-  c_git_merge_flag_t* = enum
+  c_git_merge_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_MERGE_FIND_RENAMES     = 1 shl 0
     c_GIT_MERGE_FAIL_ON_CONFLICT = 1 shl 1
     c_GIT_MERGE_SKIP_REUC        = 1 shl 2
     c_GIT_MERGE_NO_RECURSIVE     = 1 shl 3
 
-  c_git_merge_preference_t* = enum
+  c_git_merge_preference_t* {.size: sizeof(cint).} = enum
     c_GIT_MERGE_PREFERENCE_NONE             = 0 shl 0
     c_GIT_MERGE_PREFERENCE_NO_FASTFORWARD   = 1 shl 0
     c_GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY = 1 shl 1

--- a/src/hlibgit2/net.nim
+++ b/src/hlibgit2/net.nim
@@ -5,7 +5,7 @@ import
   ./oid
 
 type
-  c_git_direction* = enum
+  c_git_direction* {.size: sizeof(cint).} = enum
     c_GIT_DIRECTION_FETCH = 0 shl 0
     c_GIT_DIRECTION_PUSH  = 1 shl 0
 

--- a/src/hlibgit2/odb_backend.nim
+++ b/src/hlibgit2/odb_backend.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_odb_stream_t* = enum
+  c_git_odb_stream_t* {.size: sizeof(cint).} = enum
     c_GIT_STREAM_RDONLY = 2
     c_GIT_STREAM_WRONLY = 4
     c_GIT_STREAM_RW     = 6

--- a/src/hlibgit2/pack.nim
+++ b/src/hlibgit2/pack.nim
@@ -8,7 +8,7 @@ import
   ./types
 
 type
-  c_git_packbuilder_stage_t* = enum
+  c_git_packbuilder_stage_t* {.size: sizeof(cint).} = enum
     c_GIT_PACKBUILDER_ADDING_OBJECTS = 0 shl 0
     c_GIT_PACKBUILDER_DELTAFICATION  = 1 shl 0
 

--- a/src/hlibgit2/pathspec.nim
+++ b/src/hlibgit2/pathspec.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_pathspec_flag_t* = enum
+  c_git_pathspec_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_PATHSPEC_DEFAULT        = 0 shl 0
     c_GIT_PATHSPEC_IGNORE_CASE    = 1 shl 0
     c_GIT_PATHSPEC_USE_CASE       = 1 shl 1

--- a/src/hlibgit2/proxy.nim
+++ b/src/hlibgit2/proxy.nim
@@ -6,7 +6,7 @@ import
   ./libgit2_config
 
 type
-  c_git_proxy_t* = enum
+  c_git_proxy_t* {.size: sizeof(cint).} = enum
     c_GIT_PROXY_NONE      = 0 shl 0
     c_GIT_PROXY_AUTO      = 1 shl 0
     c_GIT_PROXY_SPECIFIED = 1 shl 1

--- a/src/hlibgit2/rebase.nim
+++ b/src/hlibgit2/rebase.nim
@@ -10,7 +10,7 @@ import
   ./types
 
 type
-  c_git_rebase_operation_t* = enum
+  c_git_rebase_operation_t* {.size: sizeof(cint).} = enum
     c_GIT_REBASE_OPERATION_PICK   = 0
     c_GIT_REBASE_OPERATION_REWORD = 1
     c_GIT_REBASE_OPERATION_EDIT   = 2

--- a/src/hlibgit2/refs.nim
+++ b/src/hlibgit2/refs.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_reference_format_t* = enum
+  c_git_reference_format_t* {.size: sizeof(cint).} = enum
     c_GIT_REFERENCE_FORMAT_NORMAL            = 0 shl 0
     c_GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL    = 1 shl 0
     c_GIT_REFERENCE_FORMAT_REFSPEC_PATTERN   = 1 shl 1

--- a/src/hlibgit2/remote.nim
+++ b/src/hlibgit2/remote.nim
@@ -15,23 +15,23 @@ import
   ./types
 
 type
-  c_git_fetch_prune_t* = enum
+  c_git_fetch_prune_t* {.size: sizeof(cint).} = enum
     c_GIT_FETCH_PRUNE_UNSPECIFIED = 0 shl 0
     c_GIT_FETCH_PRUNE             = 1 shl 0
     c_GIT_FETCH_NO_PRUNE          = 1 shl 1
 
-  c_git_remote_autotag_option_t* = enum
+  c_git_remote_autotag_option_t* {.size: sizeof(cint).} = enum
     c_GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED = 0
     c_GIT_REMOTE_DOWNLOAD_TAGS_AUTO        = 1
     c_GIT_REMOTE_DOWNLOAD_TAGS_NONE        = 2
     c_GIT_REMOTE_DOWNLOAD_TAGS_ALL         = 3
 
-  c_git_remote_completion_t* = enum
+  c_git_remote_completion_t* {.size: sizeof(cint).} = enum
     c_GIT_REMOTE_COMPLETION_DOWNLOAD = 0 shl 0
     c_GIT_REMOTE_COMPLETION_INDEXING = 1 shl 0
     c_GIT_REMOTE_COMPLETION_ERROR    = 1 shl 1
 
-  c_git_remote_create_flags* = enum
+  c_git_remote_create_flags* {.size: sizeof(cint).} = enum
     c_GIT_REMOTE_CREATE_SKIP_INSTEADOF         = 1 shl 0 ## Ignore the repository apply.insteadOf configuration
     c_GIT_REMOTE_CREATE_SKIP_DEFAULT_FETCHSPEC = 1 shl 1 ## Don't build a fetchspec from the name if none is set
 

--- a/src/hlibgit2/repository.nim
+++ b/src/hlibgit2/repository.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_repository_init_flag_t* = enum
+  c_git_repository_init_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_REPOSITORY_INIT_BARE              = 1 shl 0
     c_GIT_REPOSITORY_INIT_NO_REINIT         = 1 shl 1
     c_GIT_REPOSITORY_INIT_NO_DOTGIT_DIR     = 1 shl 2
@@ -16,12 +16,12 @@ type
     c_GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE = 1 shl 5
     c_GIT_REPOSITORY_INIT_RELATIVE_GITLINK  = 1 shl 6
 
-  c_git_repository_init_mode_t* = enum
+  c_git_repository_init_mode_t* {.size: sizeof(cint).} = enum
     c_GIT_REPOSITORY_INIT_SHARED_UMASK = 0
     c_GIT_REPOSITORY_INIT_SHARED_GROUP = 2775
     c_GIT_REPOSITORY_INIT_SHARED_ALL   = 2777
 
-  c_git_repository_item_t* = enum
+  c_git_repository_item_t* {.size: sizeof(cint).} = enum
     c_GIT_REPOSITORY_ITEM_GITDIR      = 0
     c_GIT_REPOSITORY_ITEM_WORKDIR     = 1
     c_GIT_REPOSITORY_ITEM_COMMONDIR   = 2
@@ -38,14 +38,14 @@ type
     c_GIT_REPOSITORY_ITEM_WORKTREES   = 13
     c_GIT_REPOSITORY_ITEM_LAST        = 14
 
-  c_git_repository_open_flag_t* = enum
+  c_git_repository_open_flag_t* {.size: sizeof(cint).} = enum
     c_GIT_REPOSITORY_OPEN_NO_SEARCH = 1 shl 0
     c_GIT_REPOSITORY_OPEN_CROSS_FS  = 1 shl 1
     c_GIT_REPOSITORY_OPEN_BARE      = 1 shl 2
     c_GIT_REPOSITORY_OPEN_NO_DOTGIT = 1 shl 3
     c_GIT_REPOSITORY_OPEN_FROM_ENV  = 1 shl 4
 
-  c_git_repository_state_t* = enum
+  c_git_repository_state_t* {.size: sizeof(cint).} = enum
     c_GIT_REPOSITORY_STATE_NONE                    = 0
     c_GIT_REPOSITORY_STATE_MERGE                   = 1
     c_GIT_REPOSITORY_STATE_REVERT                  = 2

--- a/src/hlibgit2/reset.nim
+++ b/src/hlibgit2/reset.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_reset_t* = enum
+  c_git_reset_t* {.size: sizeof(cint).} = enum
     c_GIT_RESET_SOFT  = 1
     c_GIT_RESET_MIXED = 2 ## Move the head to the given commit
     c_GIT_RESET_HARD  = 3 ## SOFT plus reset index to the commit

--- a/src/hlibgit2/revparse.nim
+++ b/src/hlibgit2/revparse.nim
@@ -5,7 +5,7 @@ import
   ./types
 
 type
-  c_git_revspec_t* = enum
+  c_git_revspec_t* {.size: sizeof(cint).} = enum
     c_GIT_REVSPEC_SINGLE     = 1 shl 0 ## The spec targeted a single object.
     c_GIT_REVSPEC_RANGE      = 1 shl 1 ## The spec targeted a range of commits.
     c_GIT_REVSPEC_MERGE_BASE = 1 shl 2 ## The spec used the '...' operator, which invokes special semantics.

--- a/src/hlibgit2/revwalk.nim
+++ b/src/hlibgit2/revwalk.nim
@@ -6,7 +6,7 @@ import
   ./types
 
 type
-  c_git_sort_t* = enum
+  c_git_sort_t* {.size: sizeof(cint).} = enum
     c_GIT_SORT_NONE        = 0 shl 0
     c_GIT_SORT_TOPOLOGICAL = 1 shl 0
     c_GIT_SORT_TIME        = 1 shl 1

--- a/src/hlibgit2/stash.nim
+++ b/src/hlibgit2/stash.nim
@@ -7,11 +7,11 @@ import
   ./types
 
 type
-  c_git_stash_apply_flags* = enum
+  c_git_stash_apply_flags* {.size: sizeof(cint).} = enum
     c_GIT_STASH_APPLY_DEFAULT         = 0 shl 0
     c_GIT_STASH_APPLY_REINSTATE_INDEX = 1 shl 0
 
-  c_git_stash_apply_progress_t* = enum
+  c_git_stash_apply_progress_t* {.size: sizeof(cint).} = enum
     c_GIT_STASH_APPLY_PROGRESS_NONE               = 0
     c_GIT_STASH_APPLY_PROGRESS_LOADING_STASH      = 1 ## Loading the stashed data from the object database.
     c_GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX      = 2 ## The stored index is being analyzed.
@@ -21,7 +21,7 @@ type
     c_GIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED  = 6 ## The modified files are being written to disk.
     c_GIT_STASH_APPLY_PROGRESS_DONE               = 7 ## The stash was applied successfully.
 
-  c_git_stash_flags* = enum
+  c_git_stash_flags* {.size: sizeof(cint).} = enum
     c_GIT_STASH_DEFAULT           = 0 shl 0
     c_GIT_STASH_KEEP_INDEX        = 1 shl 0
     c_GIT_STASH_INCLUDE_UNTRACKED = 1 shl 1

--- a/src/hlibgit2/status.nim
+++ b/src/hlibgit2/status.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_status_opt_t* = enum
+  c_git_status_opt_t* {.size: sizeof(cint).} = enum
     c_GIT_STATUS_OPT_INCLUDE_UNTRACKED               = 1 shl 0
     c_GIT_STATUS_OPT_INCLUDE_IGNORED                 = 1 shl 1
     c_GIT_STATUS_OPT_INCLUDE_UNMODIFIED              = 1 shl 2
@@ -25,12 +25,12 @@ type
     c_GIT_STATUS_OPT_INCLUDE_UNREADABLE              = 1 shl 14
     c_GIT_STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED = 1 shl 15
 
-  c_git_status_show_t* = enum
+  c_git_status_show_t* {.size: sizeof(cint).} = enum
     c_GIT_STATUS_SHOW_INDEX_AND_WORKDIR = 0 shl 0
     c_GIT_STATUS_SHOW_INDEX_ONLY        = 1 shl 0
     c_GIT_STATUS_SHOW_WORKDIR_ONLY      = 1 shl 1
 
-  c_git_status_t* = enum
+  c_git_status_t* {.size: sizeof(cint).} = enum
     c_GIT_STATUS_CURRENT          = 0 shl 0
     c_GIT_STATUS_INDEX_NEW        = 1 shl 0
     c_GIT_STATUS_INDEX_MODIFIED   = 1 shl 1

--- a/src/hlibgit2/submodule.nim
+++ b/src/hlibgit2/submodule.nim
@@ -9,7 +9,7 @@ import
   ./types
 
 type
-  c_git_submodule_status_t* = enum
+  c_git_submodule_status_t* {.size: sizeof(cint).} = enum
     c_GIT_SUBMODULE_STATUS_IN_HEAD           = 1 shl 0
     c_GIT_SUBMODULE_STATUS_IN_INDEX          = 1 shl 1
     c_GIT_SUBMODULE_STATUS_IN_CONFIG         = 1 shl 2

--- a/src/hlibgit2/trace.nim
+++ b/src/hlibgit2/trace.nim
@@ -4,7 +4,7 @@ import
   ./libgit2_config
 
 type
-  c_git_trace_level_t* = enum
+  c_git_trace_level_t* {.size: sizeof(cint).} = enum
     c_GIT_TRACE_NONE  = 0 ## No tracing will be performed.
     c_GIT_TRACE_FATAL = 1 ## Severe errors that may impact the program's execution
     c_GIT_TRACE_ERROR = 2 ## Errors that do not impact the program's execution

--- a/src/hlibgit2/tree.nim
+++ b/src/hlibgit2/tree.nim
@@ -6,11 +6,11 @@ import
   ./types
 
 type
-  c_git_tree_update_t* = enum
+  c_git_tree_update_t* {.size: sizeof(cint).} = enum
     c_GIT_TREE_UPDATE_UPSERT = 0 shl 0 ## Update or insert an entry at the specified path
     c_GIT_TREE_UPDATE_REMOVE = 1 shl 0 ## Remove an entry from the specified path
 
-  c_git_treewalk_mode* = enum
+  c_git_treewalk_mode* {.size: sizeof(cint).} = enum
     c_GIT_TREEWALK_PRE  = 0 shl 0
     c_GIT_TREEWALK_POST = 1 shl 0 ## Pre-order
 

--- a/src/hlibgit2/types.nim
+++ b/src/hlibgit2/types.nim
@@ -4,12 +4,12 @@ import
   ./libgit2_config
 
 type
-  c_git_branch_t* = enum
+  c_git_branch_t* {.size: sizeof(cint).} = enum
     c_GIT_BRANCH_LOCAL  = 1
     c_GIT_BRANCH_REMOTE = 2
     c_GIT_BRANCH_ALL    = 3
 
-  c_git_filemode_t* = enum
+  c_git_filemode_t* {.size: sizeof(cint).} = enum
     c_GIT_FILEMODE_UNREADABLE      = 0
     c_GIT_FILEMODE_TREE            = 40000
     c_GIT_FILEMODE_BLOB            = 100644
@@ -17,7 +17,7 @@ type
     c_GIT_FILEMODE_LINK            = 120000
     c_GIT_FILEMODE_COMMIT          = 160000
 
-  c_git_object_t* = enum
+  c_git_object_t* {.size: sizeof(cint).} = enum
     c_GIT_OBJECT_ANY       = -2
     c_GIT_OBJECT_INVALID   = -1 ## Object can be any of the following
     c_GIT_OBJECT_COMMIT    = 1  ## Object is invalid.
@@ -27,25 +27,25 @@ type
     c_GIT_OBJECT_OFS_DELTA = 6  ## An annotated tag object.
     c_GIT_OBJECT_REF_DELTA = 7  ## A delta, base is given by an offset.
 
-  c_git_reference_t* = enum
+  c_git_reference_t* {.size: sizeof(cint).} = enum
     c_GIT_REFERENCE_INVALID  = 0
     c_GIT_REFERENCE_DIRECT   = 1 ## Invalid reference
     c_GIT_REFERENCE_SYMBOLIC = 2 ## A reference that points at an object id
     c_GIT_REFERENCE_ALL      = 3 ## A reference that points at another reference
 
-  c_git_submodule_ignore_t* = enum
+  c_git_submodule_ignore_t* {.size: sizeof(cint).} = enum
     c_GIT_SUBMODULE_IGNORE_UNSPECIFIED = -1
     c_GIT_SUBMODULE_IGNORE_NONE        = 1  ## use the submodule's configuration
     c_GIT_SUBMODULE_IGNORE_UNTRACKED   = 2  ## any change or untracked == dirty
     c_GIT_SUBMODULE_IGNORE_DIRTY       = 3  ## dirty if tracked files change
     c_GIT_SUBMODULE_IGNORE_ALL         = 4  ## only dirty if HEAD moved
 
-  c_git_submodule_recurse_t* = enum
+  c_git_submodule_recurse_t* {.size: sizeof(cint).} = enum
     c_GIT_SUBMODULE_RECURSE_NO       = 0 shl 0
     c_GIT_SUBMODULE_RECURSE_YES      = 1 shl 0
     c_GIT_SUBMODULE_RECURSE_ONDEMAND = 1 shl 1
 
-  c_git_submodule_update_t* = enum
+  c_git_submodule_update_t* {.size: sizeof(cint).} = enum
     c_GIT_SUBMODULE_UPDATE_DEFAULT  = 0
     c_GIT_SUBMODULE_UPDATE_CHECKOUT = 1
     c_GIT_SUBMODULE_UPDATE_REBASE   = 2

--- a/src/hlibgit2/worktree.nim
+++ b/src/hlibgit2/worktree.nim
@@ -7,7 +7,7 @@ import
   ./types
 
 type
-  c_git_worktree_prune_t* = enum
+  c_git_worktree_prune_t* {.size: sizeof(cint).} = enum
     c_GIT_WORKTREE_PRUNE_VALID        = 1 shl 0 ## Prune working tree even if working tree is valid
     c_GIT_WORKTREE_PRUNE_LOCKED       = 1 shl 1 ## Prune working tree even if it is locked
     c_GIT_WORKTREE_PRUNE_WORKING_TREE = 1 shl 2 ## Prune checked out working tree


### PR DESCRIPTION
Most (if not all) C compilers uses cint as the backing unit for enums, so lets follow suit.
This fixes ABI mismatch between nimskull code and C code, preventing memory errors due to C code modifying more bytes than expected.

This issue was observed in nimph where git_branch_next's modification to the value pointed to by (git_branch_t*) corrupted the nim stack as the nim side expected a 1 byte value and not 4 bytes as the C code.